### PR TITLE
Add the base_notebook dockerfile

### DIFF
--- a/01_base_notebook/Dockerfile
+++ b/01_base_notebook/Dockerfile
@@ -1,0 +1,108 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+FROM nvidia/cuda:8.0-cudnn5-runtime-ubuntu14.04
+
+MAINTAINER Lab41
+
+USER root
+
+# Install all OS dependencies for fully functional notebook server
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get install -yq --no-install-recommends \
+    build-essential \
+    bzip2 \
+    ca-certificates \
+    emacs \
+    git \
+    inkscape \
+    libsm6 \
+    libxrender1 \
+    locales \
+    pandoc \
+    python-dev \
+    sudo \
+    texlive-fonts-extra \
+    texlive-fonts-recommended \
+    texlive-generic-recommended \
+    texlive-latex-base \
+    texlive-latex-extra \
+    unzip \
+    vim \
+    wget \
+    && apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set the locale
+RUN locale-gen en_US.UTF-8 && \
+    update-locale LANG=en_US.UTF-8
+
+# Install Tini
+RUN wget --quiet https://github.com/krallin/tini/releases/download/v0.9.0/tini && \
+    echo "faafbfb5b079303691a939a747d7f60591f2143164093727e870b289a44d9872 *tini" | sha256sum -c - && \
+    mv tini /usr/local/bin/tini && \
+    chmod +x /usr/local/bin/tini
+
+# Configure environment
+ENV CONDA_DIR /opt/conda
+ENV PATH $CONDA_DIR/bin:$PATH
+ENV SHELL /bin/bash
+ENV NB_USER jovyan
+ENV NB_UID 1000
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+# Create jovyan user with UID=1000 and in the 'users' group
+RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
+    mkdir -p /opt/conda && \
+    chown $NB_USER /opt/conda
+
+USER $NB_USER
+
+# Setup jovyan home directory
+RUN mkdir /home/$NB_USER/work && \
+    mkdir /home/$NB_USER/.jupyter && \
+    mkdir /home/$NB_USER/.local && \
+    echo "cacert=/etc/ssl/certs/ca-certificates.crt" > /home/$NB_USER/.curlrc
+
+# Install conda as jovyan
+RUN cd /tmp && \
+    mkdir -p $CONDA_DIR && \
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-3.19.0-Linux-x86_64.sh && \
+    echo "9ea57c0fdf481acf89d816184f969b04bc44dea27b258c4e86b1e3a25ff26aa0 *Miniconda3-3.19.0-Linux-x86_64.sh" | sha256sum -c - && \
+    /bin/bash Miniconda3-3.19.0-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
+    rm Miniconda3-3.19.0-Linux-x86_64.sh && \
+    $CONDA_DIR/bin/conda install --quiet --yes conda==3.19.1 && \
+    conda clean -tipsy
+
+# Install Jupyter notebook as jovyan
+RUN conda install --quiet --yes \
+    'notebook=4.1*' \
+    terminado \
+    && conda clean -tipsy
+
+# Install JupyterHub to get the jupyterhub-singleuser startup script
+RUN pip install 'jupyterhub==0.5'
+
+USER root
+
+# Configure container startup as root
+EXPOSE 8888
+WORKDIR /home/$NB_USER/work
+ENTRYPOINT ["tini", "--"]
+CMD ["start-notebook.sh"]
+
+# Add local files as late as possible to avoid cache busting
+COPY start.sh /usr/local/bin/
+# Start notebook server
+COPY start-notebook.sh /usr/local/bin/
+# Start single-user notebook server for use with JupyterHub
+COPY start-singleuser.sh /usr/local/bin/
+COPY jupyter_notebook_config.py /home/$NB_USER/.jupyter/
+RUN chown -R $NB_USER:users /home/$NB_USER/.jupyter
+# Need to chmod them as I can run as $NB_USER
+RUN chown -R $NB_USER:users /usr/local/bin/
+
+# Switch back to jovyan to avoid accidental container runs as root
+USER $NB_USER

--- a/01_base_notebook/jupyter_notebook_config.py
+++ b/01_base_notebook/jupyter_notebook_config.py
@@ -1,0 +1,39 @@
+# Copyright (c) Jupyter Development Team.
+from jupyter_core.paths import jupyter_data_dir
+import subprocess
+import os
+import errno
+import stat
+
+PEM_FILE = os.path.join(jupyter_data_dir(), 'notebook.pem')
+
+c = get_config()
+c.NotebookApp.ip = '*'
+c.NotebookApp.port = 8888
+c.NotebookApp.open_browser = False
+
+# Set a certificate if USE_HTTPS is set to any value
+if 'USE_HTTPS' in os.environ:
+    if not os.path.isfile(PEM_FILE):
+        # Ensure PEM_FILE directory exists
+        dir_name = os.path.dirname(PEM_FILE)
+        try:
+            os.makedirs(dir_name)
+        except OSError as exc: # Python >2.5
+            if exc.errno == errno.EEXIST and os.path.isdir(dir_name):
+                pass
+            else: raise
+        # Generate a certificate if one doesn't exist on disk
+        subprocess.check_call(['openssl', 'req', '-new', 
+            '-newkey', 'rsa:2048', '-days', '365', '-nodes', '-x509',
+            '-subj', '/C=XX/ST=XX/L=XX/O=generated/CN=generated',
+            '-keyout', PEM_FILE, '-out', PEM_FILE])
+        # Restrict access to PEM_FILE
+        os.chmod(PEM_FILE, stat.S_IRUSR | stat.S_IWUSR)
+    c.NotebookApp.certfile = PEM_FILE
+
+# Set a password if PASSWORD is set
+if 'PASSWORD' in os.environ:
+    from IPython.lib import passwd
+    c.NotebookApp.password = passwd(os.environ['PASSWORD'])
+    del os.environ['PASSWORD']

--- a/01_base_notebook/start-notebook.sh
+++ b/01_base_notebook/start-notebook.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+# Handle special flags if we're root
+if [ $UID == 0 ] ; then
+    # Change UID of NB_USER to NB_UID if it does not match
+    if [ "$NB_UID" != $(id -u $NB_USER) ] ; then
+        usermod -u $NB_UID $NB_USER
+        chown -R $NB_UID $CONDA_DIR
+    fi
+
+    # Enable sudo if requested
+    if [ ! -z "$GRANT_SUDO" ]; then
+        echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook
+    fi
+
+    # Start the notebook server
+    exec su $NB_USER -c "env PATH=$PATH jupyter notebook $*"
+else
+    # Otherwise just exec the notebook
+    exec jupyter notebook $*
+fi

--- a/01_base_notebook/start-singleuser.sh
+++ b/01_base_notebook/start-singleuser.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+set -e
+
+notebook_arg=""
+if [ -n "${NOTEBOOK_DIR:+x}" ]
+then
+    notebook_arg="--notebook-dir=${NOTEBOOK_DIR}"
+fi
+
+exec jupyterhub-singleuser \
+  --port=8888 \
+  --ip=0.0.0.0 \
+  --user=$JPY_USER \
+  --cookie-name=$JPY_COOKIE_NAME \
+  --base-url=$JPY_BASE_URL \
+  --hub-prefix=$JPY_HUB_PREFIX \
+  --hub-api-url=$JPY_HUB_API_URL \
+  ${notebook_arg} \
+  $@

--- a/01_base_notebook/start.sh
+++ b/01_base_notebook/start.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+set -e
+
+# Handle special flags if we're root
+if [ $UID == 0 ] ; then
+    # Change UID of NB_USER to NB_UID if it does not match
+    if [ "$NB_UID" != $(id -u $NB_USER) ] ; then
+        usermod -u $NB_UID $NB_USER
+        chown -R $NB_UID $CONDA_DIR .
+    fi
+
+    # Enable sudo if requested
+    if [ ! -z "$GRANT_SUDO" ]; then
+        echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook
+    fi
+
+    # Exec the command as NB_USER
+    exec su $NB_USER -c "env PATH=$PATH $*"
+else
+    # Exec the command
+    exec $*
+fi


### PR DESCRIPTION
This dockerfile will set up the minimum needed to get Jupyter notebooks
working, but does not install any of the useful libraries one might
desire. We will want to add those later.

This file comes from jupyter/docker-stacks, which is licensed under a
modified 3-clause BSD license; as such I have included a copyright
header in each file.