### PR TITLE
Add TensorFlow 0.11 to the Dockerfile

### DIFF
--- a/01_base_notebook/Dockerfile
+++ b/01_base_notebook/Dockerfile
@@ -119,6 +119,7 @@ RUN conda install --quiet --yes \
     'cloudpickle=0.1*' \
     'cython=0.24*' \
     'dill=0.2*' \
+    'gensim=0.12*' \
     'h5py=2.6*' \
     'ipywidgets=5.2*' \
     'matplotlib=1.5*' \
@@ -126,6 +127,7 @@ RUN conda install --quiet --yes \
     'numexpr=2.6*' \
     'pandas=0.18*' \
     'patsy=0.4*' \
+    'pillow=3.4*' \
     'scikit-image=0.12*' \
     'scikit-learn=0.18*' \
     'scipy=0.18*' \

--- a/02_deep_learning/Dockerfile
+++ b/02_deep_learning/Dockerfile
@@ -1,5 +1,4 @@
-#FROM lab41/base_notebook
-FROM l41-base-test
+FROM lab41/base_notebook
 
 USER root
 

--- a/02_deep_learning/Dockerfile
+++ b/02_deep_learning/Dockerfile
@@ -1,0 +1,19 @@
+#FROM lab41/base_notebook
+FROM l41-base-test
+
+USER root
+
+# Install git, bc and dependencies
+RUN apt-get update && apt-get install -yq --no-install-recommends \
+    software-properties-common \
+    rsync \
+    && apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+USER $NB_USER
+
+# Install Tensorflow
+ENV TENSORFLOW_VERSION 0.11.0rc2
+ENV TF_BINARY_URL=https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-${TENSORFLOW_VERSION}-cp35-cp35m-linux_x86_64.whl
+RUN pip --no-cache-dir install \
+    $TF_BINARY_URL


### PR DESCRIPTION
This adds TensorFlow 0.11 to the dockerfile. It also adds a few more libraries (that we used to install at the same time as TF) to the base image.

It introduces an annoyance: there are now two notebooks! One called "Python [conda root]" and one called "Python [default]". See: https://github.com/jupyter/notebook/issues/1716 I think it is worth merging while I try to remove one of them.