### PR TITLE
Add `numpy` to the base Dockerfile

### DIFF
--- a/01_base_notebook/Dockerfile
+++ b/01_base_notebook/Dockerfile
@@ -125,6 +125,7 @@ RUN conda install --quiet --yes \
     'matplotlib=1.5*' \
     'numba=0.29*' \
     'numexpr=2.6*' \
+    'numpy=1.11*' \
     'pandas=0.18*' \
     'patsy=0.4*' \
     'pillow=3.4*' \


### PR DESCRIPTION
It is required by (and so installed by) TensorFlow, but we should include it by default.