### PR TITLE
Add pulling of Docker images to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ language: generic
 services:
   - docker
 
+# Pull the latest versions of the docker images to speed up compilation
+before_script:
+  - docker pull lab41/base-notebook
+  - docker pull lab41/tensorflow-notebook
+
 script:
   - docker build -t lab41/base-notebook 01_base_notebook
   - docker build -t lab41/tensorflow-notebook 02_deep_learning


### PR DESCRIPTION
This will pull images before trying to build them, speeding up build time by not having to rebuild older layers.