### PR TITLE
Add nbgallery integration extension to 02_ganymede layer.

### DIFF
--- a/02_ganymede/Dockerfile
+++ b/02_ganymede/Dockerfile
@@ -29,6 +29,12 @@ COPY ganymede/* /srv/ganymede_nbserver/
 RUN chmod -R a+rx /srv/ganymede_nbserver/ && \
     pip install -r /srv/ganymede_nbserver/requirements.txt
 
+#### ======= nbgallery integration stuff below ======
+
+RUN git clone https://github.com/nbgallery/nbgallery-extensions.git /srv/nbgallery_extension && \
+    pip install /srv/nbgallery_extension/. && \
+    rm -rf /srv/nbgallery_extension
+
 #### ======= Nopleats logging stuff below ======
 
 # Install Mustache templater for replacing variables (maybe switch to Make?)

--- a/02_ganymede/ganymede/ganymede_nbserver.sh
+++ b/02_ganymede/ganymede/ganymede_nbserver.sh
@@ -82,6 +82,10 @@ echo "---- Theano ----"
 THEANORC="${HOME}/.theanorc"
 sudo -u $USER echo "[global]\ndevice=gpu0\nfloatX=float32\n[lib]\ncnmem=1\n[nvcc]\nfastmath=True" > $THEANORC
 
+echo "---- Add front-end nbgallery integrations ----"
+jupyter nbextension install --py jupyter_nbgallery
+jupyter nbextension enable --py jupyter_nbgallery 
+
 sudo -E THEANO_FLAGS='floatX=float32,device=gpu0,lib.cnmem=1' \
     -E PATH="${CONDA_DIR}/bin:$PATH" \
     -E PYTHONPATH="${PYTHONPATH}" \

--- a/02_ganymede/ganymede/jupyter_notebook_config.py
+++ b/02_ganymede/ganymede/jupyter_notebook_config.py
@@ -1,7 +1,7 @@
-c.NotebookApp.server_extensions = [
-    'ganymede.ganymede',
-    'jupyter_nbgallery'
-]
+c.NotebookApp.nbserver_extensions = {
+    'ganymede.ganymede': 'ganymede.ganymede',
+    'jupyter_nbgallery': 'jupyter_nbgallery'
+}
 c.NotebookApp.allow_origin = 'https://nb.gallery'
 
 from ganymede.ganymede import GanymedeHandler

--- a/02_ganymede/ganymede/jupyter_notebook_config.py
+++ b/02_ganymede/ganymede/jupyter_notebook_config.py
@@ -1,6 +1,8 @@
 c.NotebookApp.server_extensions = [
     'ganymede.ganymede',
+    'jupyter_nbgallery'
 ]
+c.NotebookApp.allow_origin = 'https://nb.gallery'
 
 from ganymede.ganymede import GanymedeHandler
 import logstash


### PR DESCRIPTION
In summary, this extension adds a few REST endpoints to a Jupyter notebook server that allows for integration with nbgallery.

The changes in the config file restricts https://nb.gallery as the only valid origin for cross-origin requests.