### PR TITLE
Log notebook file path by default.

### DIFF
--- a/02_ganymede/ganymede/jupyter_notebook_config.py
+++ b/02_ganymede/ganymede/jupyter_notebook_config.py
@@ -1,6 +1,6 @@
 c.NotebookApp.nbserver_extensions = {
-    'ganymede.ganymede': 'ganymede.ganymede',
-    'jupyter_nbgallery': 'jupyter_nbgallery'
+    'ganymede.ganymede': True,
+    'jupyter_nbgallery': True
 }
 c.NotebookApp.allow_origin = 'https://nb.gallery'
 

--- a/02_ganymede/ganymede/jupyter_notebook_config.py
+++ b/02_ganymede/ganymede/jupyter_notebook_config.py
@@ -15,3 +15,5 @@ if {"L41_LOGSTASH_HOST", "L41_GANYMEDE_PORT"} < set(os.environ):
             version=1,
         )
     ]
+
+GanymedeHandler.include_filepath = True


### PR DESCRIPTION
Set a config variable in jupyter_notebook_config.py to tell Ganymede logger to log file paths.